### PR TITLE
Taskmaster 5.3a

### DIFF
--- a/app/src/main/java/com/egconley/taskmaster/AddATask.java
+++ b/app/src/main/java/com/egconley/taskmaster/AddATask.java
@@ -1,33 +1,43 @@
 package com.egconley.taskmaster;
 
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.recyclerview.widget.RecyclerView;
 
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.os.Message;
 import android.util.Log;
 import android.view.View;
+import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.EditText;
+import android.widget.Spinner;
+import android.widget.SpinnerAdapter;
 import android.widget.Toast;
 
 import com.amazonaws.amplify.generated.graphql.CreateTaskMutation;
-import com.amazonaws.amplify.generated.graphql.CreateTeamMutation;
-import com.amazonaws.amplify.generated.graphql.CreateTeamMutation;
+import com.amazonaws.amplify.generated.graphql.ListTeamsQuery;
 import com.amazonaws.mobile.config.AWSConfiguration;
 import com.amazonaws.mobileconnectors.appsync.AWSAppSyncClient;
 import com.apollographql.apollo.GraphQLCall;
 import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.exception.ApolloException;
 
+import java.util.Arrays;
+import java.util.HashMap;
+
 import javax.annotation.Nonnull;
 
 import type.CreateTaskInput;
-import type.CreateTeamInput;
 
 public class AddATask extends AppCompatActivity {
 
     String TAG = "egc.addATask";
 
     private AWSAppSyncClient mAWSAppSyncClient;
+    RecyclerView recyclerView;
+    ArrayAdapter<String> adapter;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -39,15 +49,44 @@ public class AddATask extends AppCompatActivity {
                 .awsConfiguration(new AWSConfiguration(getApplicationContext()))
                 .build();
 
-        Button button3 = findViewById(R.id.button3);
+        final Spinner spinner = findViewById(R.id.spinner);
+        final String[] spinnerTeams = new String[3];
+        ListTeamsQuery teams = ListTeamsQuery.builder().build();
+        final HashMap<String, String> teamHashmap = new HashMap<>();
+        mAWSAppSyncClient.query(teams).enqueue(new GraphQLCall.Callback<ListTeamsQuery.Data>() {
+            @Override
+            public void onResponse(@Nonnull Response<ListTeamsQuery.Data> response) {
+                int idx = 0;
+                for (ListTeamsQuery.Item team : response.data().listTeams().items()) {
+                    teamHashmap.put(team.name(), team.id());
+                    spinnerTeams[idx] = team.name();
+                    idx++;
+                }
+                
+                adapter = new ArrayAdapter<>(getApplicationContext(), android.R.layout.simple_spinner_item, spinnerTeams);
+                adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+
+                Handler threadHandler = new Handler(Looper.getMainLooper()) {
+                    public void handleMessage(Message msg) {
+                        spinner.setAdapter(adapter);
+                    }
+                };
+                threadHandler.obtainMessage().sendToTarget();
+            }
+
+            @Override
+            public void onFailure(@Nonnull ApolloException e) {
+                Log.i("ran", "failed to pull from db");
+            }
+        });
+
+        Button button3 = findViewById(R.id.addTaskButton);
 
         button3.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 EditText newTaskTitle = findViewById(R.id.addTaskName);
                 EditText newTaskBody = findViewById(R.id.addTaskBody);
-
-
 
                 CreateTaskInput input = CreateTaskInput.builder()
                         .title(newTaskTitle.getText().toString())

--- a/app/src/main/java/com/egconley/taskmaster/AddATask.java
+++ b/app/src/main/java/com/egconley/taskmaster/AddATask.java
@@ -9,6 +9,7 @@ import android.os.Looper;
 import android.os.Message;
 import android.util.Log;
 import android.view.View;
+import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.EditText;
@@ -31,13 +32,14 @@ import javax.annotation.Nonnull;
 
 import type.CreateTaskInput;
 
-public class AddATask extends AppCompatActivity {
+public class AddATask extends AppCompatActivity implements AdapterView.OnItemSelectedListener {
 
     String TAG = "egc.addATask";
 
     private AWSAppSyncClient mAWSAppSyncClient;
     RecyclerView recyclerView;
     ArrayAdapter<String> adapter;
+    String selectedTeamID = "";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -62,13 +64,14 @@ public class AddATask extends AppCompatActivity {
                     spinnerTeams[idx] = team.name();
                     idx++;
                 }
-                
+
                 adapter = new ArrayAdapter<>(getApplicationContext(), android.R.layout.simple_spinner_item, spinnerTeams);
                 adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
 
                 Handler threadHandler = new Handler(Looper.getMainLooper()) {
                     public void handleMessage(Message msg) {
                         spinner.setAdapter(adapter);
+//                        spinner.setOnItemSelectedListener(AddATask.this);
                     }
                 };
                 threadHandler.obtainMessage().sendToTarget();
@@ -88,10 +91,14 @@ public class AddATask extends AppCompatActivity {
                 EditText newTaskTitle = findViewById(R.id.addTaskName);
                 EditText newTaskBody = findViewById(R.id.addTaskBody);
 
+
+                String selectTeam = spinner.getSelectedItem().toString();
+
                 CreateTaskInput input = CreateTaskInput.builder()
                         .title(newTaskTitle.getText().toString())
                         .body(newTaskBody.getText().toString())
                         .state("new")
+                        .taskTeamId(teamHashmap.get(selectTeam))
                         .build();
 
                 mAWSAppSyncClient.mutate(CreateTaskMutation.builder().input(input).build()).enqueue(
@@ -112,5 +119,15 @@ public class AddATask extends AppCompatActivity {
                 toast.show();
             }
         });
+    }
+
+    @Override
+    public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+
+    }
+
+    @Override
+    public void onNothingSelected(AdapterView<?> parent) {
+
     }
 }

--- a/app/src/main/res/layout/activity_add_atask.xml
+++ b/app/src/main/res/layout/activity_add_atask.xml
@@ -21,8 +21,16 @@
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_bias="0.22" />
 
+    <Spinner
+        android:id="@+id/spinner"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toTopOf="@+id/addTaskButton"
+        app:layout_constraintStart_toStartOf="@+id/addTaskBody"
+        app:layout_constraintTop_toBottomOf="@+id/addTaskBody" />
+
     <Button
-        android:id="@+id/button3"
+        android:id="@+id/addTaskButton"
         style="@style/Widget.AppCompat.Button.Colored"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -38,22 +46,36 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="52dp"
+        android:autofillHints=""
         android:ems="10"
         android:inputType="textPersonName"
-        android:text="@string/my_task"
         app:layout_constraintStart_toStartOf="@+id/textView2"
-        app:layout_constraintTop_toBottomOf="@+id/textView2"
-        android:autofillHints="" />
+        app:layout_constraintTop_toBottomOf="@+id/textView2" />
 
     <EditText
         android:id="@+id/addTaskBody"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="52dp"
+        android:autofillHints=""
         android:ems="10"
         android:inputType="textPersonName"
-        android:text="@string/do_something"
         app:layout_constraintStart_toStartOf="@+id/addTaskName"
-        app:layout_constraintTop_toBottomOf="@+id/addTaskName"
-        android:autofillHints="" />
+        app:layout_constraintTop_toBottomOf="@+id/addTaskName" />
+
+    <TextView
+        android:id="@+id/textView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="What's the task?"
+        app:layout_constraintBottom_toTopOf="@+id/addTaskName"
+        app:layout_constraintStart_toStartOf="@+id/addTaskName" />
+
+    <TextView
+        android:id="@+id/textView3"
+        android:layout_width="0dp"
+        android:layout_height="17dp"
+        android:text="Include some details:"
+        app:layout_constraintBottom_toTopOf="@+id/addTaskBody"
+        app:layout_constraintStart_toStartOf="@+id/addTaskBody" />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
- [X] Create a second entity for a team, which has a name and a list of tasks. Update tasks to be owned by a team.
- [X] Manually create three teams by running a mutation exactly three times in your code.
-[X] Modify Add Task form to include either a Spinner or Radio Buttons for which team that task belongs to.
- [ ] In addition to a username, allow the user to choose their team on the Settings page. Use that Team to display only that team’s tasks on the homepage.